### PR TITLE
Remove `fs` and `path` imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node typescript parser
+# browser typescript parser
 
 This package is a TypeScript and ECMAScript parser. It uses the underlying typescript parser to generate
 a more or less human readable AST out of .js or .ts files.
@@ -26,9 +26,6 @@ const parser = new TypescriptParser();
 
 // either:
 const parsed = await parser.parseSource(/* typescript source code as string */);
-
-// or a filepath
-const parsed = await parser.parseFile('/user/myfile.ts', 'workspace root');
 ```
 
 You can also parse multiple files at ones.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeScript-Heroes/node-typescript-parser.git"
+    "url": "https://github.com/omarVodiaK/node-typescript-parser.git"
   },
   "keywords": [
     "typescript",
@@ -28,9 +28,9 @@
   "author": "Christoph Bühler <christoph.buehler@bluewin.ch>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/TypeScript-Heroes/node-typescript-parser/issues"
+    "url": "https://github.com/omarVodiaK/node-typescript-parser/issues"
   },
-  "homepage": "https://github.com/TypeScript-Heroes/node-typescript-parser#readme",
+  "homepage": "https://github.com/omarVodiaK/node-typescript-parser#readme",
   "devDependencies": {
     "@smartive/tslint-config": "^4.0.0",
     "@types/jest": "^23.3.1",

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'fs';
-import { parse } from 'path';
 import {
     ClassDeclaration,
     createSourceFile,
@@ -64,61 +62,6 @@ export class TypescriptParser {
                 true,
                 scriptKind),
             '/');
-    }
-
-    /**
-     * Parses a single file into a parsed file.
-     *
-     * @param {string} filePath
-     * @param {string} rootPath
-     * @returns {Promise<File>}
-     *
-     * @memberof TsResourceParser
-     */
-    public async parseFile(filePath: string, rootPath: string): Promise<File> {
-        const parse = await this.parseFiles([filePath], rootPath);
-        return parse[0];
-    }
-
-    /**
-     * Parses multiple files into parsed files.
-     *
-     * @param {string[]} filePathes
-     * @param {string} rootPath
-     * @returns {Promise<File[]>}
-     *
-     * @memberof TsResourceParser
-     */
-    public async parseFiles(
-        filePathes: string[],
-        rootPath: string): Promise<File[]> {
-        return filePathes
-            .map((o) => {
-                let scriptKind: ScriptKind = ScriptKind.Unknown;
-                const parsed = parse(o);
-                switch (parsed.ext.toLowerCase()) {
-                    case 'js':
-                        scriptKind = ScriptKind.JS;
-                        break;
-                    case 'jsx':
-                        scriptKind = ScriptKind.JSX;
-                        break;
-                    case 'ts':
-                        scriptKind = ScriptKind.TS;
-                        break;
-                    case 'tsx':
-                        scriptKind = ScriptKind.TSX;
-                        break;
-                }
-                return createSourceFile(
-                    o,
-                    readFileSync(o).toString(),
-                    ScriptTarget.ES2015,
-                    true,
-                    scriptKind,
-                );
-            })
-            .map(o => this.parseTypescript(o, rootPath));
     }
 
     /**


### PR DESCRIPTION
We need to have both `fs` and `path` imports removed in the parser because we are using this package to parse files in the browser. The browser have no access to `fs` nor `path`.